### PR TITLE
Develop sendingtk v3.11.0 03082024

### DIFF
--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -64,6 +64,7 @@ class DashboardController < ActionController::Base
       FACEBOOK_API_VERSION: GlobalConfigService.load('FACEBOOK_API_VERSION', 'v18.0'),
       IS_ENTERPRISE: ChatwootApp.enterprise?,
       AZURE_APP_ID: GlobalConfigService.load('AZURE_APP_ID', ''),
+      UNOAPI_AUTH_TOKEN: GlobalConfigService.load('UNOAPI_AUTH_TOKEN', ''),
       GIT_SHA: GIT_HASH
     }
   end

--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -32,7 +32,8 @@ class DashboardController < ActionController::Base
       'LOGOUT_REDIRECT_LINK',
       'DISABLE_USER_PROFILE_UPDATE',
       'DEPLOYMENT_ENV',
-      'CSML_EDITOR_HOST', 'CONVESATION_STYLE_CSS'
+      'CSML_EDITOR_HOST',
+      'CONVESATION_STYLE_CSS'
     ).merge(app_config)
   end
 

--- a/app/controllers/super_admin/app_configs_controller.rb
+++ b/app/controllers/super_admin/app_configs_controller.rb
@@ -39,6 +39,8 @@ class SuperAdmin::AppConfigsController < SuperAdmin::ApplicationController
                          %w[AZURE_APP_ID AZURE_APP_SECRET]
                        when 'email'
                          ['MAILER_INBOUND_EMAIL_DOMAIN']
+                       when 'unoapi'
+                          %w[UNOAPI_AUTH_TOKEN]
                        else
                          %w[ENABLE_ACCOUNT_SIGNUP FIREBASE_PROJECT_ID FIREBASE_CREDENTIALS]
                        end

--- a/app/services/whatsapp/providers/unoapi_service.rb
+++ b/app/services/whatsapp/providers/unoapi_service.rb
@@ -1,6 +1,6 @@
 class Whatsapp::Providers::UnoapiService < Whatsapp::Providers::WhatsappCloudService
   def validate_provider_config?
-    url = "#{business_account_path}/message_templates?access_token=#{ENV.fetch('UNOAPI_AUTH_TOKEN', whatsapp_channel.provider_config['api_key'])}"
+    url = "#{business_account_path}/message_templates?access_token=#{GlobalConfigService.load('UNOAPI_AUTH_TOKEN', whatsapp_channel.provider_config['api_key'])}"
     return Whatsapp::UnoapiWebhookSetupService.new.perform(whatsapp_channel) if HTTParty.get(url).success?
   end
 end

--- a/app/services/whatsapp/providers/whatsapp_cloud_service.rb
+++ b/app/services/whatsapp/providers/whatsapp_cloud_service.rb
@@ -56,7 +56,7 @@ class Whatsapp::Providers::WhatsappCloudService < Whatsapp::Providers::BaseServi
   end
 
   def media_url(media_id)
-    "#{api_base_path}/v13.0/#{media_id}"
+    "#{api_base_path}/v20.0/#{media_id}"
   end
 
   def message_update_payload(message)
@@ -88,7 +88,7 @@ class Whatsapp::Providers::WhatsappCloudService < Whatsapp::Providers::BaseServi
 
   # TODO: See if we can unify the API versions and for both paths and make it consistent with out facebook app API versions
   def phone_id_path
-    "#{api_base_path}/v13.0/#{whatsapp_channel.provider_config['phone_number_id']}"
+    "#{api_base_path}/v20.0/#{whatsapp_channel.provider_config['phone_number_id']}"
   end
 
   def messages_path

--- a/app/services/whatsapp/unoapi_webhook_setup_service.rb
+++ b/app/services/whatsapp/unoapi_webhook_setup_service.rb
@@ -69,7 +69,7 @@ class Whatsapp::UnoapiWebhookSetupService
 
   def headers(whatsapp_channel)
     {
-      Authorization: ENV.fetch('UNOAPI_AUTH_TOKEN', whatsapp_channel.provider_config['api_key']),
+      Authorization: GlobalConfigService.load('UNOAPI_AUTH_TOKEN', whatsapp_channel.provider_config['api_key']),
       'Content-Type': 'application/json'
     }
   end

--- a/config/installation_config.yml
+++ b/config/installation_config.yml
@@ -133,6 +133,13 @@
   locked: false
 # End of Microsoft Email Channel Config
 
+# MARK: UNOAPI Channel Config
+- NAME: UNOAPI_AUTH_TOKEN
+  value:
+  display_title: 'UNO API Auth Token'
+  description: 'The Auth Token for UNO API. Find more details on how to configure UNOAPI here: https://github.com/clairton/unoapi-cloud/tree/main'
+# End of UNOAPI Channel Config
+
 # ------- Chatwoot Internal Config for Cloud ----#
 - name: CHATWOOT_INBOX_TOKEN
   value:

--- a/config/installation_config.yml
+++ b/config/installation_config.yml
@@ -134,7 +134,7 @@
 # End of Microsoft Email Channel Config
 
 # MARK: UNOAPI Channel Config
-- NAME: UNOAPI_AUTH_TOKEN
+- name: UNOAPI_AUTH_TOKEN
   value:
   display_title: 'UNO API Auth Token'
   description: 'The Auth Token for UNO API. Find more details on how to configure UNOAPI here: https://github.com/clairton/unoapi-cloud/tree/main'

--- a/enterprise/app/helpers/super_admin/features.yml
+++ b/enterprise/app/helpers/super_admin/features.yml
@@ -72,3 +72,9 @@ microsoft:
   enabled: true
   icon: 'icon-microsoft'
   config_key: 'microsoft'
+unoapi:
+  name: 'UNOAPI'
+  description: 'Configuration for setting up UNOAPI'
+  enabled: true
+  icon: 'icon-chat-smile-3-line'
+  config_key: 'unoapi'

--- a/spec/enterprise/models/inbox_spec.rb
+++ b/spec/enterprise/models/inbox_spec.rb
@@ -103,7 +103,7 @@ RSpec.describe Inbox do
     let(:inbox) { channel.inbox }
 
     before do
-      stub_request(:get, 'https://graph.facebook.com/v14.0//message_templates?access_token=test_key')
+      stub_request(:get, 'https://graph.facebook.com/v20.0/message_templates?access_token=test_key')
         .with(
           headers: {
             'Accept' => '*/*',

--- a/spec/models/attachment_spec.rb
+++ b/spec/models/attachment_spec.rb
@@ -44,13 +44,12 @@ RSpec.describe Attachment do
       }.to_json, headers: {})
     end
 
-    it 'returns external url as data and thumb urls' do
+    it 'returns external url as data and thumb urls when message is incoming' do
       external_url = instagram_message.attachments.first.external_url
       expect(instagram_message.attachments.first.push_event_data[:data_url]).to eq external_url
     end
 
-
-    it 'returns data url as data if the message is outgoing' do
+    it 'returns original attachment url as data url if the message is outgoing' do
       message = create(:message, :instagram_story_mention, message_type: :outgoing)
       expect(message.attachments.first.push_event_data[:data_url]).not_to eq message.attachments.first.external_url
     end

--- a/spec/models/channel/whatsapp_spec.rb
+++ b/spec/models/channel/whatsapp_spec.rb
@@ -32,12 +32,12 @@ RSpec.describe Channel::Whatsapp do
     let(:channel) { build(:channel_whatsapp, provider: 'whatsapp_cloud', account: create(:account)) }
 
     it 'validates false when provider config is wrong' do
-      stub_request(:get, 'https://graph.facebook.com/v14.0//message_templates?access_token=test_key').to_return(status: 401)
+      stub_request(:get, 'https://graph.facebook.com/v20.0/message_templates?access_token=test_key').to_return(status: 401)
       expect(channel.save).to be(false)
     end
 
     it 'validates true when provider config is right' do
-      stub_request(:get, 'https://graph.facebook.com/v14.0//message_templates?access_token=test_key')
+      stub_request(:get, 'https://graph.facebook.com/v20.0/message_templates?access_token=test_key')
         .to_return(status: 200,
                    body: { data: [{
                      id: '123456789', name: 'test_template'

--- a/spec/services/whatsapp/providers/whatsapp_cloud_service_spec.rb
+++ b/spec/services/whatsapp/providers/whatsapp_cloud_service_spec.rb
@@ -25,7 +25,7 @@ describe Whatsapp::Providers::WhatsappCloudService do
   describe '#send_message' do
     context 'when called' do
       it 'calls message endpoints for normal messages' do
-        stub_request(:post, 'https://graph.facebook.com/v13.0/123456789/messages')
+        stub_request(:post, 'https://graph.facebook.com/v20.0/123456789/messages')
           .with(
             body: {
               messaging_product: 'whatsapp',
@@ -40,7 +40,7 @@ describe Whatsapp::Providers::WhatsappCloudService do
       end
 
       it 'calls message endpoints for a reply to messages' do
-        stub_request(:post, 'https://graph.facebook.com/v13.0/123456789/messages')
+        stub_request(:post, 'https://graph.facebook.com/v20.0/123456789/messages')
           .with(
             body: {
               messaging_product: 'whatsapp',
@@ -60,7 +60,7 @@ describe Whatsapp::Providers::WhatsappCloudService do
         attachment = message.attachments.new(account_id: message.account_id, file_type: :image)
         attachment.file.attach(io: Rails.root.join('spec/assets/avatar.png').open, filename: 'avatar.png', content_type: 'image/png')
 
-        stub_request(:post, 'https://graph.facebook.com/v13.0/123456789/messages')
+        stub_request(:post, 'https://graph.facebook.com/v20.0/123456789/messages')
           .with(
             body: hash_including({
                                    messaging_product: 'whatsapp',
@@ -79,7 +79,7 @@ describe Whatsapp::Providers::WhatsappCloudService do
 
         # ref: https://github.com/bblimke/webmock/issues/900
         # reason for Webmock::API.hash_including
-        stub_request(:post, 'https://graph.facebook.com/v13.0/123456789/messages')
+        stub_request(:post, 'https://graph.facebook.com/v20.0/123456789/messages')
           .with(
             body: hash_including({
                                    messaging_product: 'whatsapp',
@@ -106,7 +106,7 @@ describe Whatsapp::Providers::WhatsappCloudService do
                                        { title: 'Sushi', value: 'Sushi' }
                                      ]
                                    })
-        stub_request(:post, 'https://graph.facebook.com/v13.0/123456789/messages')
+        stub_request(:post, 'https://graph.facebook.com/v20.0/123456789/messages')
           .with(
             body: {
               messaging_product: 'whatsapp', to: '+123456789',
@@ -134,7 +134,7 @@ describe Whatsapp::Providers::WhatsappCloudService do
                                        { title: 'Salad', value: 'Salad' }
                                      ]
                                    })
-        stub_request(:post, 'https://graph.facebook.com/v13.0/123456789/messages')
+        stub_request(:post, 'https://graph.facebook.com/v20.0/123456789/messages')
           .with(
             body: {
               messaging_product: 'whatsapp', to: '+123456789',
@@ -184,7 +184,7 @@ describe Whatsapp::Providers::WhatsappCloudService do
 
     context 'when called' do
       it 'calls message endpoints with template params for template messages' do
-        stub_request(:post, 'https://graph.facebook.com/v13.0/123456789/messages')
+        stub_request(:post, 'https://graph.facebook.com/v20.0/123456789/messages')
           .with(
             body: template_body.to_json
           )


### PR DESCRIPTION
[chore: bump Facebook API to v20 in Whatsapp Cloud service, avoids dep…]
[feat: move UNOAPI_AUTH_TOKEN config to installation_config]
[fix: feat: move UNOAPI_AUTH_TOKEN config to installation_config]
















